### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,12 @@
     "ts-jest": "^29.1.0",
     "typedoc": "^0.24.6",
     "typescript": "^4.6.4"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.