### PR TITLE
use node v24 and delete npm i --before in workflows

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '18'
+          node-version: '24'
           cache: npm
       - name: Install and Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,27 +24,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - name: Make value for before option
-        id: date-value
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7.1.0
-        with:
-          script: |
-            const dt = new Date()
-            dt.setDate(dt.getDate() - 7)
-            const beforeDate = dt.toLocaleDateString("ja-JP", {year: "numeric", month: "2-digit", day: "2-digit"}).replaceAll('/', '-')
-            return beforeDate
-          result-encoding: string
       - name: Prepare
         run: |
-          npm i --before ${DATE_VALUE}
-          if [[ `git status --porcelain` ]]; then
-            echo "- npm install results in changes!"
-            exit 1
-          fi
+          npm ci
           npm test
           npm shrinkwrap
-        env:
-          DATE_VALUE: ${{ steps.date-value.outputs.result }}
       - name: Publish and Release
         uses: akashic-games/action-release@14c9885ffa51f0f5b8590da0d0139b577bebefcf # v3.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [18.x, 20.x]
+        node: [24.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
### やったこと
- Github Actions ワークフローでNode v24を利用するように（package.jsonでnpmのバージョンを11.11.0以上に指定しているため）
- release.yml で `npm i --before` している箇所を削除